### PR TITLE
fix(e2e): Correctly ignore favicon.ico 404 errors in console test

### DIFF
--- a/tests/e2e/console.spec.js
+++ b/tests/e2e/console.spec.js
@@ -11,7 +11,8 @@ describe('E2E Console Errors', () => {
 
     page.on('console', msg => {
       const text = msg.text();
-      if (msg.type() === 'error' && !text.includes('favicon.ico') && !text.includes('runtime.lastError')) {
+      const location = msg.location();
+      if (msg.type() === 'error' && !location.url.includes('favicon.ico') && !text.includes('runtime.lastError')) {
         errors.push(text);
       }
     });


### PR DESCRIPTION
The e2e test was failing due to a 404 error for `favicon.ico`. The test was intended to ignore this error, but the filter was checking the error message text instead of the URL. This change updates the filter to check the URL from the error's location, which correctly ignores the favicon error and allows the test to pass.